### PR TITLE
feat: Todo 생성 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+	// runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'io.rest-assured:rest-assured'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dalim/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/dalim/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.dalim.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/dalim/common/domain/BaseTimeEntity.java
+++ b/src/main/java/com/dalim/common/domain/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package com.dalim.common.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/dalim/sprint/application/SprintService.java
+++ b/src/main/java/com/dalim/sprint/application/SprintService.java
@@ -1,0 +1,22 @@
+package com.dalim.sprint.application;
+
+import com.dalim.sprint.domain.Sprint;
+import com.dalim.sprint.domain.repository.SprintRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SprintService {
+
+    private final SprintRepository sprintRepository;
+
+    @Transactional
+    public Sprint getOrCreateSprint(final LocalDateTime due) {
+        return sprintRepository.findByDate(due.toLocalDate())
+            .orElseGet(() -> sprintRepository.save(new Sprint(due, due.toLocalDate())));
+    }
+}

--- a/src/main/java/com/dalim/sprint/domain/Sprint.java
+++ b/src/main/java/com/dalim/sprint/domain/Sprint.java
@@ -1,6 +1,7 @@
 package com.dalim.sprint.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -10,10 +11,12 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Sprint {
 
     @Id

--- a/src/main/java/com/dalim/sprint/domain/Sprint.java
+++ b/src/main/java/com/dalim/sprint/domain/Sprint.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -21,4 +22,11 @@ public class Sprint {
 
     @CreatedDate
     private LocalDateTime createdAt;
+
+    private LocalDate date;
+
+    public Sprint(final LocalDateTime createdAt, final LocalDate date) {
+        this.createdAt = createdAt;
+        this.date = date;
+    }
 }

--- a/src/main/java/com/dalim/sprint/domain/Sprint.java
+++ b/src/main/java/com/dalim/sprint/domain/Sprint.java
@@ -1,0 +1,24 @@
+package com.dalim.sprint.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Sprint {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/dalim/sprint/domain/repository/SprintRepository.java
+++ b/src/main/java/com/dalim/sprint/domain/repository/SprintRepository.java
@@ -1,0 +1,11 @@
+package com.dalim.sprint.domain.repository;
+
+import com.dalim.sprint.domain.Sprint;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SprintRepository extends JpaRepository<Sprint, Long> {
+
+    Optional<Sprint> findByDate(final LocalDate date);
+}

--- a/src/main/java/com/dalim/todo/application/TodoService.java
+++ b/src/main/java/com/dalim/todo/application/TodoService.java
@@ -1,10 +1,32 @@
 package com.dalim.todo.application;
 
+import com.dalim.sprint.application.SprintService;
+import com.dalim.sprint.domain.Sprint;
+import com.dalim.todo.domain.Todo;
+import com.dalim.todo.domain.repository.TodoRepository;
+import com.dalim.todo.ui.dto.TodoRequest;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class TodoService {
 
+    private final TodoRepository todoRepository;
+    private final SprintService sprintService;
+
+    @Transactional
+    public Long create(final TodoRequest request) {
+        final Instant instant = Instant.ofEpochSecond(request.due());
+        final LocalDateTime due = instant.atZone(ZoneId.systemDefault()).toLocalDateTime();
+        final Sprint sprint = sprintService.getOrCreateSprint(due);
+
+        final Todo todo = request.toEntity(sprint);
+        return todoRepository.save(todo).getId();
+    }
 }

--- a/src/main/java/com/dalim/todo/application/TodoService.java
+++ b/src/main/java/com/dalim/todo/application/TodoService.java
@@ -1,0 +1,10 @@
+package com.dalim.todo.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class TodoService {
+
+}

--- a/src/main/java/com/dalim/todo/domain/Todo.java
+++ b/src/main/java/com/dalim/todo/domain/Todo.java
@@ -37,4 +37,10 @@ public class Todo {
 
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    public Todo(final Sprint sprint, final String content, final boolean done) {
+        this.sprint = sprint;
+        this.content = content;
+        this.done = done;
+    }
 }

--- a/src/main/java/com/dalim/todo/domain/Todo.java
+++ b/src/main/java/com/dalim/todo/domain/Todo.java
@@ -2,6 +2,7 @@ package com.dalim.todo.domain;
 
 import com.dalim.sprint.domain.Sprint;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -14,10 +15,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Todo {
 
     @Id

--- a/src/main/java/com/dalim/todo/domain/Todo.java
+++ b/src/main/java/com/dalim/todo/domain/Todo.java
@@ -1,0 +1,40 @@
+package com.dalim.todo.domain;
+
+import com.dalim.sprint.domain.Sprint;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Todo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sprint_id")
+    private Sprint sprint;
+
+    private String content;
+
+    private boolean done;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/dalim/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/com/dalim/todo/domain/repository/TodoRepository.java
@@ -1,0 +1,7 @@
+package com.dalim.todo.domain.repository;
+
+import com.dalim.todo.domain.Todo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TodoRepository extends JpaRepository<Todo, Long> {
+}

--- a/src/main/java/com/dalim/todo/ui/TodoController.java
+++ b/src/main/java/com/dalim/todo/ui/TodoController.java
@@ -1,0 +1,8 @@
+package com.dalim.todo.ui;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TodoController {
+
+}

--- a/src/main/java/com/dalim/todo/ui/TodoController.java
+++ b/src/main/java/com/dalim/todo/ui/TodoController.java
@@ -18,8 +18,8 @@ public class TodoController {
     private final TodoService todoService;
 
     @PostMapping
-    public ResponseEntity<Void> createTodo(@RequestBody TodoRequest request) {
-        final Long id = 0L;
+    public ResponseEntity<Void> createTodo(@RequestBody final TodoRequest request) {
+        final Long id = todoService.create(request);
         return ResponseEntity.created(URI.create("/todos/" + id)).build();
     }
 }

--- a/src/main/java/com/dalim/todo/ui/TodoController.java
+++ b/src/main/java/com/dalim/todo/ui/TodoController.java
@@ -1,8 +1,25 @@
 package com.dalim.todo.ui;
 
+import com.dalim.todo.application.TodoService;
+import com.dalim.todo.ui.dto.TodoRequest;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/todos")
 public class TodoController {
 
+    private final TodoService todoService;
+
+    @PostMapping
+    public ResponseEntity<Void> createTodo(@RequestBody TodoRequest request) {
+        final Long id = 0L;
+        return ResponseEntity.created(URI.create("/todos/" + id)).build();
+    }
 }

--- a/src/main/java/com/dalim/todo/ui/dto/TodoRequest.java
+++ b/src/main/java/com/dalim/todo/ui/dto/TodoRequest.java
@@ -1,0 +1,8 @@
+package com.dalim.todo.ui.dto;
+
+public record TodoRequest(
+        String content,
+        Long due,
+        boolean done
+) {
+}

--- a/src/main/java/com/dalim/todo/ui/dto/TodoRequest.java
+++ b/src/main/java/com/dalim/todo/ui/dto/TodoRequest.java
@@ -1,8 +1,15 @@
 package com.dalim.todo.ui.dto;
 
+import com.dalim.sprint.domain.Sprint;
+import com.dalim.todo.domain.Todo;
+
 public record TodoRequest(
         String content,
         Long due,
         boolean done
 ) {
+
+    public Todo toEntity(final Sprint sprint) {
+        return new Todo(sprint, content, done);
+    }
 }

--- a/src/test/java/com/dalim/sprint/application/SprintServiceTest.java
+++ b/src/test/java/com/dalim/sprint/application/SprintServiceTest.java
@@ -1,0 +1,71 @@
+package com.dalim.sprint.application;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.dalim.sprint.domain.Sprint;
+import com.dalim.sprint.domain.repository.SprintRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class SprintServiceTest {
+
+    @Mock
+    private SprintRepository sprintRepository;
+
+    @InjectMocks
+    private SprintService sprintService;
+
+    @Nested
+    class getOrCreateSprint_테스트 {
+
+        @Test
+        void 해당_날짜의_스프린트가_존재하면_해당_스프린트를_반환한다() {
+            // given
+            final LocalDateTime due = LocalDateTime.parse("2024-01-01T12:00:00");
+            given(sprintRepository.findByDate(any()))
+                    .willReturn(Optional.of(new Sprint(due, due.toLocalDate())));
+
+            // when
+            final Sprint sprint = sprintService.getOrCreateSprint(due);
+
+            // then
+            assertSoftly(softly -> {
+                assertEquals(due, sprint.getCreatedAt());
+                assertEquals(due.toLocalDate(), sprint.getDate());
+            });
+        }
+
+        @Test
+        void 해당_날짜의_스프린트가_존재하지_않으면_새로운_스프린트를_생성한다() {
+            // given
+            final LocalDateTime due = LocalDateTime.parse("2024-01-01T12:00:00");
+            given(sprintRepository.findByDate(any()))
+                    .willReturn(Optional.empty());
+            given(sprintRepository.save(any()))
+                    .willReturn(new Sprint(due, due.toLocalDate()));
+
+            // when
+            final Sprint sprint = sprintService.getOrCreateSprint(due);
+
+            // then
+            assertSoftly(softly -> {
+                assertEquals(due, sprint.getCreatedAt());
+                assertEquals(due.toLocalDate(), sprint.getDate());
+            });
+        }
+    }
+}

--- a/src/test/java/com/dalim/sprint/domain/repository/SprintRepositoryTest.java
+++ b/src/test/java/com/dalim/sprint/domain/repository/SprintRepositoryTest.java
@@ -1,0 +1,56 @@
+package com.dalim.sprint.domain.repository;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.dalim.sprint.domain.Sprint;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class SprintRepositoryTest {
+
+    @Autowired
+    private SprintRepository sprintRepository;
+
+    @BeforeEach
+    void setUp() {
+        final LocalDateTime createdAt = LocalDateTime.parse("2024-01-01T12:00:00");
+        final Sprint sprint = new Sprint(createdAt, createdAt.toLocalDate());
+        sprintRepository.save(sprint);
+    }
+
+    @Nested
+    class findByDate_테스트 {
+
+        @Test
+        void 해당_날짜의_스프린트를_조회한다() {
+            // given
+            // when
+            final Optional<Sprint> actual = sprintRepository.findByDate(LocalDate.parse("2024-01-01"));
+
+            // then
+            assertTrue(actual.isPresent());
+        }
+
+        @Test
+        void 해당_날짜의_스프린트가_존재하지_않으면_값을_반환하지_않는다() {
+            // given
+            // when
+            final Optional<Sprint> actual = sprintRepository.findByDate(LocalDate.parse("2024-01-02"));
+
+            // then
+            assertFalse(actual.isPresent());
+        }
+    }
+}

--- a/src/test/java/com/dalim/todo/application/TodoServiceTest.java
+++ b/src/test/java/com/dalim/todo/application/TodoServiceTest.java
@@ -1,0 +1,58 @@
+package com.dalim.todo.application;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.dalim.sprint.application.SprintService;
+import com.dalim.sprint.domain.Sprint;
+import com.dalim.todo.domain.Todo;
+import com.dalim.todo.domain.repository.TodoRepository;
+import com.dalim.todo.ui.dto.TodoRequest;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class TodoServiceTest {
+
+    @Mock
+    private TodoRepository todoRepository;
+
+    @Mock
+    private SprintService sprintService;
+
+    @InjectMocks
+    private TodoService todoService;
+
+    @Nested
+    class create_테스트 {
+
+        @Test
+        void todo를_생성한다() {
+            // given
+            final TodoRequest request = new TodoRequest("content", 1704078000L, false);
+            final Sprint sprint = new Sprint(LocalDateTime.parse("2024-01-01T12:00:00"), LocalDate.parse("2024-01-01"));
+            given(sprintService.getOrCreateSprint(any()))
+                    .willReturn(sprint);
+            final Todo todo = new Todo(sprint, "content", false);
+            given(todoRepository.save(any()))
+                    .willReturn(todo);
+
+            // when
+            todoService.create(request);
+
+            // then
+            verify(todoRepository).save(any());
+        }
+    }
+}

--- a/src/test/java/com/dalim/todo/ui/TodoControllerTest.java
+++ b/src/test/java/com/dalim/todo/ui/TodoControllerTest.java
@@ -1,0 +1,46 @@
+package com.dalim.todo.ui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dalim.todo.ui.dto.TodoRequest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class TodoControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    void todo를_추가한다() {
+        // given
+        final TodoRequest request = new TodoRequest("content", 1704078000L, false);
+
+        // when
+        final var response = RestAssured.given()
+                .body(request)
+                .contentType("application/json")
+                .when()
+                .post("/api/todos")
+                .then()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+}


### PR DESCRIPTION
## Issue

- close #2 

## ✨ 구현한 기능

- Todo 생성 기능 구현
  - Todo 생성 시 해당 날짜의 Sprint가 존재하는지 확인
    (없으면 Sprint 생성 후 Todo 생성)
  - 구현한 기능들에 대한 Service, Repository, Controller 테스트 추가

## 📢 특이 사항

- Sprint에 date 추가
  - 해당 날짜의 Sprint가 생성되어 있는지 쉽게 확인하기 위해 date 필드 추가
- 우선 Member 엔티티 없이 구현했는데, 이건 로그인 구현 완료되면 추가하고 해당 부분들 수정하도록 하죠
- 패키지 구조랑 테스트 방식도 이거 보고 이건 별로다 싶은 거 있으면 수정해가면서 정하죠

## ⏰ 일정

- 추정 시간 : 2h
- 걸린 시간 : 4h
